### PR TITLE
fix the titlebar blinking issue in obsidian v0.15.6

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1391,7 +1391,7 @@ body.hider-frameless .titlebar {
   transition: opacity 100ms ease-out;
 }
 .titlebar-button {
-  opacity: 0.5;
+  opacity: 1;
   cursor: var(--cursor);
   color: var(--text-muted);
   padding: 2px 4px;


### PR DESCRIPTION
Obsidian release v0.15.6 has revamped  the app menu on macOS (See [here](https://forum.obsidian.md/t/obsidian-release-v0-15-6/40227#striving-to-feel-more-native-on-macos-5)). It brings up a problem that the titlebar will blinking when the mouse hovers in or out the titlebar buttons.

This little changes can fix the problem. 😊