### PR TITLE
feat: allow to disable uppercase for h4

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -153,6 +153,7 @@ For help and/or CSS snippets, thanks to:
   --font-todoist-metadata-size: small;
 
   --cursor: default;
+  --h4-transform: uppercase;
 }
 
 /* Desktop fonts */
@@ -651,7 +652,7 @@ button,
   font-size: var(--h4) !important;
   color: var(--h4-color);
   font-weight: var(--h4-weight) !important;
-  text-transform: uppercase;
+  text-transform: var(--h4-transform);
 }
 .markdown-preview-view h5,
 .HyperMD-header-5 .cm-header-5,
@@ -6870,6 +6871,19 @@ settings:
         type: variable-color
         format: hex
         default: '#E5B567'
+    -
+        id: h4-transform
+        title: H4 transform
+        description: Transform the H4 heading text
+        type: variable-select
+        default: uppercase
+        options:
+            -
+                label: Uppercase
+                value: uppercase
+            -
+                label: None
+                value: none
     - 
         id: level-5-headings
         title: Level 5 Headings


### PR DESCRIPTION
Hello!
I love using this theme in Obsidian but the uppercase present for the h4 headings has been bothering me for a while.

This PR creates a new configuration flag available in the `Style Settings` plugin page to disable the uppercase transform.
The default value remains `uppercase` so that it won't change anything for existing users.

<img width="607" alt="image" src="https://user-images.githubusercontent.com/57704682/184478720-a2fc8814-83d4-440d-b1f8-f13a4a7b4709.png">

I hope you are ok with this change 😄 