### PR TITLE
feat: allow inline code blocks color customisation

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -310,7 +310,8 @@ body {
   /* --tag-font-color: rgb(29, 105, 75); */
   --tag-font-color-l: #1d694b;
 
-  --code-color: #5c5c5c;
+  --code-color-l: #5c5c5c;
+  --code-color: var(--code-color-l);
   --atom-gray-1: #383a42;
   --atom-gray-2: #383a42;
   --atom-red: #e75545;
@@ -428,7 +429,8 @@ body {
   --tag-background-color-d: rgb(29, 105, 75);
   --tag-font-color-d: var(--text-normal);
 
-  --code-color: #a6a6a6;
+  --code-color-d: #a6a6a6;
+  --code-color: var(--code-color-d);
   --atom-gray-1: #5c6370;
   --atom-gray-2: #abb2bf;
   --atom-red: #e06c75;
@@ -6703,6 +6705,18 @@ settings:
         type: variable-color
         format: hex
         default: '#3EB4BF' 
+    -
+        id: code-color-l
+        title: Inline code blocks font color (Light mode)
+        type: variable-color
+        format: hex
+        default: '#5C5C5C'
+    -
+        id: code-color-d
+        title: Inline code blocks font color (Dark mode)
+        type: variable-color
+        format: hex
+        default: '#A6A6A6'
     - 
         id: tag-background-color-l
         title: Tag background color (Light mode)

--- a/obsidian.css
+++ b/obsidian.css
@@ -6698,7 +6698,7 @@ settings:
         format: hex
         default: '#FF82B2' 
     - 
-        id: green
+        id: code-color
         title: Blockquotes font color
         type: variable-color
         format: hex

--- a/obsidian.css
+++ b/obsidian.css
@@ -6698,7 +6698,7 @@ settings:
         format: hex
         default: '#FF82B2' 
     - 
-        id: code-color
+        id: green
         title: Blockquotes font color
         type: variable-color
         format: hex


### PR DESCRIPTION
Add a new 'Style Setting' to change the inline code blocks color for Light and Dark themes.

For example:
<img width="660" alt="image" src="https://user-images.githubusercontent.com/57704682/185226255-feb69f18-3786-48b6-82f1-239eeb4d80cd.png">
Light:
<img width="145" alt="image" src="https://user-images.githubusercontent.com/57704682/185226288-d69379cb-0b9e-4158-a169-6c60685150b5.png">
Dark:
<img width="142" alt="image" src="https://user-images.githubusercontent.com/57704682/185226358-401024ff-31be-45af-be00-ac58ce283815.png">

