### PR TITLE
Fix #96

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -241,6 +241,14 @@ body {
   --atom-blue: #61afef;
   --atom-yellow: #e5c07b;
 }
+/* Make exported PDFs render correctly */ 
+@media print {
+  .theme-dark {
+    --highlight-mix-blend-mode: darken;
+	--color-base-30: #ebedf0;
+	--h1-color: var(--color-base-00);
+  }
+}
 
 /* H2 styling */
 h2,


### PR DESCRIPTION
Ensures notes exported as PDFs from dark mode are displayed correctly.