### PR TITLE
Collapsable list checkboxes now align

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -347,6 +347,11 @@ body:not(.default-font-color) mark em {
   color: var(--text-faint);
 }
 
+/* Collapsing list checkboxes alignment */
+.markdown-rendered .list-collapse-indicator {
+    margin-left: -4em;
+}
+
 /* Image card */
 img {
   border-radius: 4px;


### PR DESCRIPTION
When creating checkboxes as part of a collapsable list, they didn't align correctly.

**Before**
<img width="649" alt="after" src="https://user-images.githubusercontent.com/2418930/233775179-8d7ef616-a91e-499e-a6db-a06f5e2a33a7.png">

**After**
<img width="649" alt="after" src="https://user-images.githubusercontent.com/2418930/233775184-beedb52e-f010-44b4-a221-5e6d83e015f9.png">
