### PR TITLE
Add checkboxes for draft, open, and merged PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Things supports a wide number of alternate checkbox types. These allow you to ca
 - [w] win
 - [u] up
 - [d] down
+- [D] draft pull request
+- [P] open pull request
+- [M] merged pull request
 ```
 
 ## Installation

--- a/theme.css
+++ b/theme.css
@@ -685,6 +685,9 @@ input[data-task='l']:checked,
 input[data-task='p']:checked,
 input[data-task='u']:checked,
 input[data-task='w']:checked,
+input[data-task='P']:checked, /* Open PR */
+input[data-task='M']:checked, /* Merged PR */
+input[data-task='D']:checked, /* Draft PR */
 li[data-task='!'] > input:checked,
 li[data-task='!'] > p > input:checked,
 li[data-task='*'] > input:checked,
@@ -714,7 +717,13 @@ li[data-task='p'] > p > input:checked,
 li[data-task='u'] > input:checked,
 li[data-task='u'] > p > input:checked,
 li[data-task='w'] > input:checked,
-li[data-task='w'] > p > input:checked {
+li[data-task='w'] > p > input:checked,
+li[data-task='P'] > input:checked,
+li[data-task='P'] > p > input:checked,
+li[data-task='M'] > input:checked,
+li[data-task='M'] > p > input:checked,
+li[data-task='D'] > input:checked,
+li[data-task='D'] > p > input:checked {
   --checkbox-marker-color: transparent;
   border: none;
   border-radius: 0;
@@ -914,6 +923,24 @@ li[data-task='b'] > p > input:checked {
   color: var(--color-orange);
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath d='M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z' /%3E%3C/svg%3E");
 }
+input[data-task='P']:checked,
+li[data-task='P'] > input:checked,
+li[data-task='P'] > p > input:checked {
+  color: var(--color-green);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z'%3E%3C/path%3E%3C/svg%3E");
+}
+input[data-task='M']:checked,
+li[data-task='M'] > input:checked,
+li[data-task='M'] > p > input:checked {
+  color: var(--color-purple);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0 0 .005V3.25Z'%3E%3C/path%3E%3C/svg%3E");
+}
+input[data-task='D']:checked,
+li[data-task='D'] > input:checked,
+li[data-task='D'] > p > input:checked {
+  color: var(--color-base-50);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 14a2.25 2.25 0 1 1 0-4.5 2.25 2.25 0 0 1 0 4.5ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM14 7.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm0-4.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z'%3E%3C/path%3E%3C/svg%3E");
+}
 
 body:not(.tasks) li[data-task='>'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='<'].task-list-item.is-checked,
@@ -933,7 +960,9 @@ body:not(.tasks) li[data-task='f'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='k'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='w'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='u'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='d'].task-list-item.is-checked {
+body:not(.tasks) li[data-task='d'].task-list-item.is-checked,
+body:not(.tasks) li[data-task='P'].task-list-item.is-checked,
+body:not(.tasks) li[data-task='M'].task-list-item.is-checked {
   color: var(--text-normal);
 }
 


### PR DESCRIPTION
Hi @colineckert — thanks for your work on this theme! This is a _totally speculative_ PR, and you should feel free to close it (e.g. on the grounds that it adds checkbox styles unique to this theme).

## Changes

Adds three new checkbox styles for typical GitHub workflows:

+ `- [D]` indicates a `D`raft pull request.
+ `- [P]` indicates an open `P`ull request. Maybe you'd prefer `O`?
+ `- [M]` indicates a `M`erged pull request.

Uses [MIT-licensed icons ("Octicons") from GitHub Primer](https://primer.style/design/foundations/icons):

![Screenshot 2023-05-12 at 7 11 21 PM](https://github.com/colineckert/obsidian-things/assets/4955943/bd9642ec-79a5-4270-9443-84d58fd7daa1)

Unfortunately, these aren't captured in the README.md screenshot yet.

## Motivation

I use Obsidian at work, and work involves submitting PRs. Draft and open PRs are both _partially_ completed tasks, but they're meaningfully different workflow states (blocked on me, blocked on a reviewer).

Using `- [/]` obscures that distinction!

I realize _exhaustively_ adding checkboxes — for every workflow, or even just for developer workflows — would clutter this library. Set the limit where you see fit!