### PR TITLE
Use faint text for merged PR checkboxes [M]

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -961,7 +961,8 @@ body:not(.tasks) li[data-task='k'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='w'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='u'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='d'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='P'].task-list-item.is-checked {
+body:not(.tasks) li[data-task='P'].task-list-item.is-checked,
+body:not(.tasks) li[data-task='D'].task-list-item.is-checked {
   color: var(--text-normal);
 }
 

--- a/theme.css
+++ b/theme.css
@@ -961,8 +961,7 @@ body:not(.tasks) li[data-task='k'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='w'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='u'].task-list-item.is-checked,
 body:not(.tasks) li[data-task='d'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='P'].task-list-item.is-checked,
-body:not(.tasks) li[data-task='M'].task-list-item.is-checked {
+body:not(.tasks) li[data-task='P'].task-list-item.is-checked {
   color: var(--text-normal);
 }
 

--- a/theme.css
+++ b/theme.css
@@ -342,7 +342,8 @@ body:not(.default-font-color) mark em {
 /* Completed checkboxes */
 .markdown-preview-view ul > li.task-list-item.is-checked,
 .markdown-source-view.mod-cm6 .HyperMD-task-line[data-task='x'],
-.markdown-source-view.mod-cm6 .HyperMD-task-line[data-task='X'] {
+.markdown-source-view.mod-cm6 .HyperMD-task-line[data-task='X'],
+.markdown-source-view.mod-cm6 .HyperMD-task-line[data-task='M'] {
   text-decoration: none;
   color: var(--text-faint);
 }


### PR DESCRIPTION
## Changes

+ Fix https://github.com/colineckert/obsidian-things/issues/140
+ Fix a bug in https://github.com/colineckert/obsidian-things/pull/132: use the normal font appearance for [D]raft PR items in reader mode.

## Testing

Reading mode

<img width="289" alt="Screenshot 2023-06-14 at 10 37 25 AM" src="https://github.com/colineckert/obsidian-things/assets/4955943/9069aef5-dc4a-4758-8f46-0d2ed5f7aba9">

Editing mode

<img width="277" alt="Screenshot 2023-06-14 at 10 37 21 AM" src="https://github.com/colineckert/obsidian-things/assets/4955943/b33a6d55-72c1-494e-bb95-17f837db0582">

