### PR TITLE
Fix default --h2-color

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -35,7 +35,7 @@ body {
   --purple: #9e86c8;
 
   --h1-color: var(--text-normal);
-  --h2-color: var(--text-normal);
+  --h2-color: var(--blue);
   --h3-color: var(--blue);
   --h4-color: var(--yellow);
   --h5-color: var(--red);


### PR DESCRIPTION
Hi, thanks for the nice theme!

The Style Settings plugin shows that the default color of H2 is `#2E80F2`, but I see black headings.

When I set it to another value, `#2E80F3` for example, then they changed to blue.

Seeing theme.css, the default `--h2-color` is set to `--text-normal`. So let's revert it to `--blue`, to match with screenshot: https://github.com/colineckert/obsidian-things/blob/main/assets/main-demo.png