### PR TITLE
Fix line numbers hiding code in fancy-code block styling

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -428,7 +428,7 @@ body.fancy-code
   line-height: 2;
   text-align: right;
   height: 100%;
-  width: 1.7em;
+  width: 2.1em;
   color: var(--text-muted);
   /* background-color: #1e2029; */
   background-color: var(--code-background);
@@ -442,7 +442,7 @@ body.fancy-code
     .HyperMD-codeblock-begin,
     .HyperMD-codeblock-end
   ) {
-  padding-left: 2.8em;
+  padding-left: 2.6em !important;
 }
 
 body.fancy-code .cm-s-obsidian div.HyperMD-codeblock-begin-bg {

--- a/theme.css
+++ b/theme.css
@@ -438,11 +438,11 @@ body.fancy-code
 }
 
 body.fancy-code
-  .HyperMD-codeblock.cm-line:not(
+  .HyperMD-codeblock.HyperMD-codeblock-bg.cm-line:not(
     .HyperMD-codeblock-begin,
     .HyperMD-codeblock-end
   ) {
-  padding-left: 2.6em !important;
+  padding-left: 2.6em;
 }
 
 body.fancy-code .cm-s-obsidian div.HyperMD-codeblock-begin-bg {


### PR DESCRIPTION
In “fancy-code” blocks, the first two characters of code were being hidden behind the line numbers.

This small update ensures all code is fully visible and accommodates three-digit line numbers.

The fix modifies only two lines:
`width` of the line-number pseudo-element `::before` increased from `1.7em` → `2.1em`
`padding-left` of code lines changed from `2.8em` → `2.6em !important`
The use of `!important` on `padding-left` ensures it overrides other theme styles and reliably prevents the overlap.