### PR TITLE
Remove titlebar focused/unfocused state styling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Things",
-  "version": "2.2.1",
+  "version": "2.2.3",
   "minAppVersion": "1.0.0",
   "author": "@colineckert",
   "authorUrl": "https://twitter.com/colineckert"

--- a/theme.css
+++ b/theme.css
@@ -1,6 +1,6 @@
 /*───────────────────────────────────────────────────────
 THINGS
-Version 2.2.2
+Version 2.2.3
 Created by @colineckert
 
 Readme:

--- a/theme.css
+++ b/theme.css
@@ -1,6 +1,6 @@
 /*───────────────────────────────────────────────────────
 THINGS
-Version 2.2.1
+Version 2.2.2
 Created by @colineckert
 
 Readme:
@@ -322,15 +322,6 @@ body.is-mobile.theme-dark.mobile-black-background {
     --color-base-30: #ebedf0;
     --h1-color: var(--color-base-00);
   }
-}
-
-/* Titlebar focused/unfocused states */
-body:not(.hider-frameless):not(.is-fullscreen):not(.is-mobile) .titlebar {
-  background-color: var(--titlebar-background);
-}
-body.is-focused:not(.hider-frameless):not(.is-fullscreen):not(.is-mobile)
-  .titlebar {
-  background-color: var(--titlebar-background-focused);
 }
 
 /* Breadcrumb: hidden by default, visible on hover */


### PR DESCRIPTION
## Summary
Removed the CSS rules that controlled titlebar background color changes based on window focus state, and bumped the version from 2.2.1 to 2.2.2.

## Key Changes
- Deleted titlebar focused/unfocused state styling rules that conditionally applied `--titlebar-background` and `--titlebar-background-focused` variables
- Removed selectors targeting `.titlebar` element for non-frameless, non-fullscreen, non-mobile windows
- Updated version number to 2.2.2

## Details
The removed CSS rules were handling visual feedback for window focus state by changing the titlebar background color. This functionality has been removed, likely to simplify the styling or consolidate titlebar appearance handling elsewhere in the theme.

https://claude.ai/code/session_01QCXDS3yxthFxP1nYN8dkBU